### PR TITLE
fix(PKG): pad decryption buffer to blocksize to prevent buffer overflow

### DIFF
--- a/src/core/crypto/crypto.cpp
+++ b/src/core/crypto/crypto.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <array>
-
+#include <exception>
 #include "crypto.h"
 
 CryptoPP::RSA::PrivateKey Crypto::key_pkg_derived_key3_keyset_init() {
@@ -121,21 +121,20 @@ void Crypto::aesCbcCfb128Decrypt(std::span<const CryptoPP::byte, 32> ivkey,
 }
 
 void Crypto::aesCbcCfb128DecryptEntry(std::span<const CryptoPP::byte, 32> ivkey,
-                                      std::span<CryptoPP::byte> ciphertext,
+                                      std::span<const CryptoPP::byte> ciphertext,
                                       std::span<CryptoPP::byte> decrypted) {
+    if (ciphertext.size() != decrypted.size()) {
+      throw std::length_error("aesCbcCfb128DecryptEntry: plaintext and ciphertext buffers must be equal length");
+    }
+
     std::array<CryptoPP::byte, CryptoPP::AES::DEFAULT_KEYLENGTH> key;
     std::array<CryptoPP::byte, CryptoPP::AES::DEFAULT_KEYLENGTH> iv;
 
     std::copy(ivkey.begin() + 16, ivkey.begin() + 16 + key.size(), key.begin());
     std::copy(ivkey.begin(), ivkey.begin() + iv.size(), iv.begin());
 
-    CryptoPP::AES::Decryption aesDecryption(key.data(), CryptoPP::AES::DEFAULT_KEYLENGTH);
-    CryptoPP::CBC_Mode_ExternalCipher::Decryption cbcDecryption(aesDecryption, iv.data());
-
-    for (size_t i = 0; i < decrypted.size(); i += CryptoPP::AES::BLOCKSIZE) {
-        cbcDecryption.ProcessData(decrypted.data() + i, ciphertext.data() + i,
-                                  CryptoPP::AES::BLOCKSIZE);
-    }
+    CryptoPP::CBC_Mode<CryptoPP::AES>::Decryption cbcDecryption{key.data(), key.size(), iv.data()};
+    cbcDecryption.ProcessData(decrypted.data(), ciphertext.data(), decrypted.size());
 }
 
 void Crypto::decryptEFSM(std::span<CryptoPP::byte, 16> trophyKey,

--- a/src/core/crypto/crypto.h
+++ b/src/core/crypto/crypto.h
@@ -30,7 +30,7 @@ public:
                              std::span<const CryptoPP::byte, 256> ciphertext,
                              std::span<CryptoPP::byte, 256> decrypted);
     void aesCbcCfb128DecryptEntry(std::span<const CryptoPP::byte, 32> ivkey,
-                                  std::span<CryptoPP::byte> ciphertext,
+                                  std::span<const CryptoPP::byte> ciphertext,
                                   std::span<CryptoPP::byte> decrypted);
     void decryptEFSM(std::span<CryptoPP::byte, 16> trophyKey,
                      std::span<CryptoPP::byte, 16> NPcommID, std::span<CryptoPP::byte, 16> efsmIv,

--- a/src/core/file_format/pkg.cpp
+++ b/src/core/file_format/pkg.cpp
@@ -222,26 +222,26 @@ bool PKG::Extract(const std::filesystem::path& filepath, const std::filesystem::
         // Decrypt Np stuff and overwrite.
         if (entry.id == 0x400 || entry.id == 0x401 || entry.id == 0x402 ||
             entry.id == 0x403) { // somehow 0x401 is not decrypting
-            decNp.resize(entry.size);
+            size_t paddedSize = (entry.size + CryptoPP::AES::BLOCKSIZE - 1) / CryptoPP::AES::BLOCKSIZE * CryptoPP::AES::BLOCKSIZE;
+            decNp.resize(paddedSize);
             if (!file.Seek(entry.offset)) {
                 failreason = "Failed to seek to PKG entry offset";
                 return false;
             }
 
             std::vector<u8> data;
-            data.resize(entry.size);
+            data.resize(paddedSize);
             file.ReadRaw<u8>(data.data(), entry.size);
 
-            std::span<u8> cipherNp(data.data(), entry.size);
             std::array<u8, 64> concatenated_ivkey_dk3_;
             std::memcpy(concatenated_ivkey_dk3_.data(), &entry, sizeof(entry));
             std::memcpy(concatenated_ivkey_dk3_.data() + sizeof(entry), dk3_.data(), sizeof(dk3_));
             PKG::crypto.ivKeyHASH256(concatenated_ivkey_dk3_, ivKey);
-            PKG::crypto.aesCbcCfb128DecryptEntry(ivKey, cipherNp, decNp);
+            PKG::crypto.aesCbcCfb128DecryptEntry(ivKey, data, decNp);
 
             Common::FS::IOFile out(extract_path / "sce_sys" / name,
                                    Common::FS::FileAccessMode::Write);
-            out.Write(decNp);
+            out.Write(std::span(decNp.data(), entry.size));
             out.Close();
         }
 


### PR DESCRIPTION
entries are decrypted into a span backed by a vector. depending on the order of entries and their size, decrypting may write past the end of reserved memory, corrupting the heap, because the vector size isn't rounded up to the cipher block size

before decrypting, pad ciphertext and plaintext buffers with zeroes up to the block size. trim the plaintext before writing.

simplify CryptoPP usage to process whole buffers at once. clarify the Crypto interface by marking the ciphertext const. check the buffer lengths before proceeding.

should fix #8 